### PR TITLE
Minor suggestion for TAG strings

### DIFF
--- a/project_and_code_guidelines.md
+++ b/project_and_code_guidelines.md
@@ -283,7 +283,7 @@ As a general rule, we use the class name as tag and we define it as a `static fi
 
 ```java
 public class MyClass {
-    private static final String TAG = MyClass.class.getName();
+    private static final String TAG = MyClass.class.getSimpleName();
 
     public myMethod() {
         Log.e(TAG, "My error message");

--- a/project_and_code_guidelines.md
+++ b/project_and_code_guidelines.md
@@ -283,7 +283,7 @@ As a general rule, we use the class name as tag and we define it as a `static fi
 
 ```java
 public class MyClass {
-    private static final String TAG = "MyClass";
+    private static final String TAG = MyClass.class.getName();
 
     public myMethod() {
         Log.e(TAG, "My error message");


### PR DESCRIPTION
Switched to using getSimpleName() on the class object rather than hardcoding TAG strings. Ensures that the TAG is updated when class name refactoring.