### PR TITLE
Url replaced with new one

### DIFF
--- a/project_and_code_guidelines.md
+++ b/project_and_code_guidelines.md
@@ -2,7 +2,7 @@
 
 ## 1.1 Project structure
 
-New projects should follow the Android Gradle project structure that is defined on the [Android Gradle plugin user guide](http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Project-Structure). The [ribot Boilerplate](https://github.com/ribot/android-boilerplate) project is a good reference to start from.
+New projects should follow the Android Gradle project structure that is defined on the [Android Gradle plugin user guide](https://developer.android.com/studio/build/index.html). The [ribot Boilerplate](https://github.com/ribot/android-boilerplate) project is a good reference to start from.
 
 ## 1.2 File naming
 


### PR DESCRIPTION
Url provided in Gradle plugin guide have been deprecated so added new guidelines from (https://developer.android.com/studio/build/index.html)